### PR TITLE
[scripts] Fix gen-ll issue.

### DIFF
--- a/scripts/gen-ll.sh
+++ b/scripts/gen-ll.sh
@@ -19,10 +19,10 @@ for f in $*; do
   echo "[gen-ll.sh] $b: Compiling ..."
   if [ ! -e ${b}/${b}.ll ]; then
     # Generate compiled files
-    $ROOT/scaffold.sh -r $f
+    $ROOT/scaffold.sh -rk $f
     mv ${b}11.ll ${b}11.ll.keep_me
     # clean intermediary compilation files (comment out for speed)
-    $ROOT/scaffold.sh -c $f
+    $ROOT/scaffold.sh -ck $f
     # Keep the final output for the compilation
     mv ${b}11.ll.keep_me ${b}/${b}.ll
   fi


### PR DESCRIPTION
Hi ScaffCC developers,

```
$ ./scripts/gen-ll.sh Algorithms/Binary_Welded_Tree/binary_welded_tree.n100s100.scaffold
[gen-ll.sh] binary_welded_tree.n100s100: Creating output directory ...
[gen-ll.sh] binary_welded_tree.n100s100: Compiling ...
[Scaffold.makefile] Compiling binary_welded_tree.n100s100_merged.scaffold ...
[Scaffold.makefile] Transforming cbits ...
[Scaffold.makefile] O1 optimizations ...
[Scaffold.makefile] Unrolling Loops (1) ...
[Scaffold.makefile] Cloning Functions (1) ...
Functions Cloned: 16
[Scaffold.makefile] Dead Argument Elimination (1) ...
[Scaffold.makefile] Unrolling Loops (2) ...
[Scaffold.makefile] Cloning Functions (2) ...
Functions Cloned: 0
[Scaffold.makefile] Dead Argument Elimination (2) ...
[Scaffold.makefile] Decomposing Rotations ...
Calling './scripts/../Rotations/gridsynth/gridsynth "(-114.590000)" -d 4'
Calling './scripts/../Rotations/gridsynth/gridsynth "(114.590000)" -d 4'
[Scaffold.makefile] Internalizing and Removing Unused Functions ...
[Scaffold.makefile] Toffoli Decomposition ...
[Scaffold.makefile] Inserting Reverse Functions...
[Scaffold.makefile] Generating resource count ...
[Scaffold.makefile] Resources written to binary_welded_tree.n100s100.resources ...
mv: cannot stat 'binary_welded_tree.n100s10011.ll': No such file or directory
mv: cannot stat 'binary_welded_tree.n100s10011.ll.keep_me': No such file or directory
```

So I simply add `-k` to keep LLVM IR files, please review my patch, thanks a lot!

Regards,
Leslie Zhai - a LLVM developer https://reviews.llvm.org/p/xiangzhai/