### PR TITLE
Fix build break.

### DIFF
--- a/Rotations/sqct/rint.cpp
+++ b/Rotations/sqct/rint.cpp
@@ -15,7 +15,7 @@
 //     You should have received a copy of the GNU Lesser General Public License
 //     along with SQCT.  If not, see <http://www.gnu.org/licenses/>.
 // 
-
+#include <cstddef>
 #include "rint.h"
 #include "resring.h"
 


### PR DESCRIPTION
For gcc 5, need to include cstddef header file to prevent the build error.
/usr/include/c++/5/cstddef:50:11: error: ‘::max_align_t’ has not been declared